### PR TITLE
feat: optimize production deployment to reuse PR images

### DIFF
--- a/.github/workflows/pr-deployment.yml
+++ b/.github/workflows/pr-deployment.yml
@@ -82,6 +82,16 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Deploy to Acceptance Container App
+        uses: azure/CLI@v2
+        with:
+          inlineScript: |
+            echo "Deploying new image to container app (even if stopped)..."
+            az containerapp update \
+              -n ${{ env.CONTAINER_APP_ACC }} \
+              -g ${{ env.RESOURCE_GROUP }} \
+              --image ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-${{ github.sha }}
+
       - name: Start Container App
         uses: azure/CLI@v2
         with:
@@ -134,15 +144,6 @@ jobs:
 
             echo "❌ Container app failed to become ready after $MAX_ATTEMPTS attempts"
             exit 1
-
-      - name: Deploy to Acceptance Container App
-        uses: azure/CLI@v2
-        with:
-          inlineScript: |
-            az containerapp update \
-              -n ${{ env.CONTAINER_APP_ACC }} \
-              -g ${{ env.RESOURCE_GROUP }} \
-              --image ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-${{ github.sha }}
 
       - name: Get Container App URL
         id: get-url

--- a/.github/workflows/production-deployment.yml
+++ b/.github/workflows/production-deployment.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       pr_number: ${{ steps.check.outputs.pr_number }}
+      pr_head_sha: ${{ steps.check.outputs.pr_head_sha }}
       is_pr_merge: ${{ steps.check.outputs.is_pr_merge }}
 
     steps:
@@ -31,6 +32,11 @@ jobs:
           # Check if this is a merge commit
           if git rev-parse HEAD^2 >/dev/null 2>&1; then
             echo "This is a merge commit"
+
+            # Extract PR head commit SHA (the commit that was merged, not the merge commit)
+            PR_HEAD_SHA=$(git rev-parse HEAD^2)
+            echo "PR head SHA: $PR_HEAD_SHA"
+            echo "pr_head_sha=$PR_HEAD_SHA" >> $GITHUB_OUTPUT
 
             # Extract PR number from merge commit message (format: "Merge pull request #123 from...")
             PR_NUMBER=$(git log -1 --pretty=%B | grep -oP 'Merge pull request #\K\d+' || echo "")
@@ -53,6 +59,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: check-pr-merge
     if: needs.check-pr-merge.outputs.is_pr_merge == 'true'
+    outputs:
+      image_retagged: ${{ steps.retag.outputs.success }}
     permissions:
       id-token: write
       contents: read
@@ -70,32 +78,61 @@ jobs:
           az acr login --name play14containerregistry
 
       - name: Retag PR image for production
+        id: retag
+        continue-on-error: true
         run: |
           PR_NUMBER=${{ needs.check-pr-merge.outputs.pr_number }}
-          PR_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${PR_NUMBER}-${{ github.sha }}"
+          PR_HEAD_SHA=${{ needs.check-pr-merge.outputs.pr_head_sha }}
+          PR_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${PR_NUMBER}-${PR_HEAD_SHA}"
           PROD_SHA_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}"
           PROD_LATEST_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
 
-          echo "Pulling PR image: $PR_IMAGE"
-          docker pull "$PR_IMAGE"
+          echo "Looking for PR image: $PR_IMAGE"
 
-          echo "Tagging as: $PROD_SHA_IMAGE"
-          docker tag "$PR_IMAGE" "$PROD_SHA_IMAGE"
+          # Check if image exists in registry
+          if az acr repository show-tags --name play14containerregistry --repository ${{ env.IMAGE_NAME }} --output json | grep -q "pr-${PR_NUMBER}-${PR_HEAD_SHA}"; then
+            echo "✅ PR image found in registry"
 
-          echo "Tagging as: $PROD_LATEST_IMAGE"
-          docker tag "$PR_IMAGE" "$PROD_LATEST_IMAGE"
+            echo "Pulling PR image: $PR_IMAGE"
+            if docker pull "$PR_IMAGE"; then
+              echo "Tagging as: $PROD_SHA_IMAGE"
+              docker tag "$PR_IMAGE" "$PROD_SHA_IMAGE"
 
-          echo "Pushing production tags..."
-          docker push "$PROD_SHA_IMAGE"
-          docker push "$PROD_LATEST_IMAGE"
+              echo "Tagging as: $PROD_LATEST_IMAGE"
+              docker tag "$PR_IMAGE" "$PROD_LATEST_IMAGE"
 
-          echo "✅ Successfully retagged PR image for production"
+              echo "Pushing production tags..."
+              docker push "$PROD_SHA_IMAGE"
+              docker push "$PROD_LATEST_IMAGE"
+
+              echo "✅ Successfully retagged PR image for production"
+              echo "success=true" >> $GITHUB_OUTPUT
+              exit 0
+            else
+              echo "❌ Failed to pull PR image"
+              echo "success=false" >> $GITHUB_OUTPUT
+              exit 1
+            fi
+          else
+            echo "⚠️ PR image not found in registry: $PR_IMAGE"
+            echo "This could happen if:"
+            echo "  - PR was closed before acceptance deployment completed"
+            echo "  - PR deployment workflow failed"
+            echo "  - Image was manually deleted from ACR"
+            echo "Will fall back to building a new image..."
+            echo "success=false" >> $GITHUB_OUTPUT
+            exit 1
+          fi
 
   build-production:
     name: Build Production Image
     runs-on: ubuntu-latest
-    needs: check-pr-merge
-    if: needs.check-pr-merge.outputs.is_pr_merge == 'false'
+    needs: [check-pr-merge, retag-pr-image]
+    if: |
+      always() && (
+        needs.check-pr-merge.outputs.is_pr_merge == 'false' ||
+        (needs.check-pr-merge.outputs.is_pr_merge == 'true' && needs.retag-pr-image.outputs.image_retagged != 'true')
+      )
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/production-deployment.yml
+++ b/.github/workflows/production-deployment.yml
@@ -38,8 +38,12 @@ jobs:
             echo "PR head SHA: $PR_HEAD_SHA"
             echo "pr_head_sha=$PR_HEAD_SHA" >> $GITHUB_OUTPUT
 
-            # Extract PR number from merge commit message (format: "Merge pull request #123 from...")
-            PR_NUMBER=$(git log -1 --pretty=%B | grep -oP 'Merge pull request #\K\d+' || echo "")
+            # Extract PR number from merge commit message
+            # Supports both formats:
+            # - Regular merge: "Merge pull request #123 from..."
+            # - Squash merge: "feat: some title (#123)"
+            COMMIT_MSG=$(git log -1 --pretty=%B)
+            PR_NUMBER=$(echo "$COMMIT_MSG" | grep -oP 'Merge pull request #\K\d+' || echo "$COMMIT_MSG" | grep -oP '\(#\K\d+(?=\))' || echo "")
 
             if [ -n "$PR_NUMBER" ]; then
               echo "PR number: $PR_NUMBER"
@@ -62,8 +66,8 @@ jobs:
     outputs:
       image_retagged: ${{ steps.retag.outputs.success }}
     permissions:
-      id-token: write
-      contents: read
+      id-token: write    # Required for Azure federated credential authentication
+      contents: read     # Required for checking out code if needed
 
     steps:
       - name: Log in to Azure
@@ -81,10 +85,13 @@ jobs:
         id: retag
         continue-on-error: true
         run: |
+          set +e  # Don't exit on error, we handle errors explicitly
+
           PR_NUMBER=${{ needs.check-pr-merge.outputs.pr_number }}
           PR_HEAD_SHA=${{ needs.check-pr-merge.outputs.pr_head_sha }}
           PR_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${PR_NUMBER}-${PR_HEAD_SHA}"
-          PROD_SHA_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}"
+          PROD_MERGE_SHA_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}"
+          PROD_HEAD_SHA_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${PR_HEAD_SHA}"
           PROD_LATEST_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
 
           echo "Looking for PR image: $PR_IMAGE"
@@ -93,32 +100,75 @@ jobs:
           if az acr repository show-tags --name play14containerregistry --repository ${{ env.IMAGE_NAME }} --output json | grep -q "pr-${PR_NUMBER}-${PR_HEAD_SHA}"; then
             echo "✅ PR image found in registry"
 
+            # Pull PR image with retry logic
             echo "Pulling PR image: $PR_IMAGE"
-            if docker pull "$PR_IMAGE"; then
-              echo "Tagging as: $PROD_SHA_IMAGE"
-              docker tag "$PR_IMAGE" "$PROD_SHA_IMAGE"
+            RETRY=0
+            MAX_RETRIES=3
+            until docker pull "$PR_IMAGE" || [ $RETRY -eq $MAX_RETRIES ]; do
+              RETRY=$((RETRY + 1))
+              echo "Pull attempt $RETRY failed. Retrying in 5 seconds..."
+              sleep 5
+            done
 
-              echo "Tagging as: $PROD_LATEST_IMAGE"
-              docker tag "$PR_IMAGE" "$PROD_LATEST_IMAGE"
-
-              echo "Pushing production tags..."
-              docker push "$PROD_SHA_IMAGE"
-              docker push "$PROD_LATEST_IMAGE"
-
-              echo "✅ Successfully retagged PR image for production"
-              echo "success=true" >> $GITHUB_OUTPUT
-              exit 0
-            else
-              echo "❌ Failed to pull PR image"
+            if [ $RETRY -eq $MAX_RETRIES ]; then
+              echo "❌ Failed to pull PR image after $MAX_RETRIES attempts"
+              echo "This could be due to:"
+              echo "  - Network connectivity issues"
+              echo "  - Registry rate limits"
+              echo "  - Corrupted image in registry"
               echo "success=false" >> $GITHUB_OUTPUT
               exit 1
             fi
+
+            # Tag with both merge commit SHA and PR head SHA for redundancy
+            # Note: GitHub Actions runners use Docker, not Podman (which is used locally per CLAUDE.md)
+            echo "Tagging as merge commit SHA: $PROD_MERGE_SHA_IMAGE"
+            docker tag "$PR_IMAGE" "$PROD_MERGE_SHA_IMAGE"
+
+            echo "Tagging as PR head SHA: $PROD_HEAD_SHA_IMAGE"
+            docker tag "$PR_IMAGE" "$PROD_HEAD_SHA_IMAGE"
+
+            echo "Tagging as latest: $PROD_LATEST_IMAGE"
+            docker tag "$PR_IMAGE" "$PROD_LATEST_IMAGE"
+
+            # Push all tags with error handling
+            echo "Pushing production tags..."
+            PUSH_FAILED=false
+
+            if ! docker push "$PROD_MERGE_SHA_IMAGE"; then
+              echo "⚠️ Failed to push merge SHA tag"
+              PUSH_FAILED=true
+            fi
+
+            if ! docker push "$PROD_HEAD_SHA_IMAGE"; then
+              echo "⚠️ Failed to push head SHA tag"
+              PUSH_FAILED=true
+            fi
+
+            if ! docker push "$PROD_LATEST_IMAGE"; then
+              echo "⚠️ Failed to push latest tag"
+              PUSH_FAILED=true
+            fi
+
+            if [ "$PUSH_FAILED" = true ]; then
+              echo "❌ Some tags failed to push"
+              echo "success=false" >> $GITHUB_OUTPUT
+              exit 1
+            fi
+
+            echo "✅ Successfully retagged PR image for production"
+            echo "  - Merge commit SHA: ${{ github.sha }}"
+            echo "  - PR head SHA: ${PR_HEAD_SHA}"
+            echo "  - Latest tag updated"
+            echo "success=true" >> $GITHUB_OUTPUT
+            exit 0
           else
             echo "⚠️ PR image not found in registry: $PR_IMAGE"
             echo "This could happen if:"
             echo "  - PR was closed before acceptance deployment completed"
             echo "  - PR deployment workflow failed"
             echo "  - Image was manually deleted from ACR"
+            echo "  - ACR cleanup policy removed the image"
             echo "Will fall back to building a new image..."
             echo "success=false" >> $GITHUB_OUTPUT
             exit 1
@@ -128,16 +178,26 @@ jobs:
     name: Build Production Image
     runs-on: ubuntu-latest
     needs: [check-pr-merge, retag-pr-image]
+    # Run if: direct push to main OR retag failed (fallback scenario)
     if: |
       always() && (
         needs.check-pr-merge.outputs.is_pr_merge == 'false' ||
         (needs.check-pr-merge.outputs.is_pr_merge == 'true' && needs.retag-pr-image.outputs.image_retagged != 'true')
       )
     permissions:
-      id-token: write
-      contents: read
+      id-token: write    # Required for Azure federated credential authentication
+      contents: read     # Required for checking out repository code
 
     steps:
+      - name: Log fallback reason if retagging failed
+        if: needs.check-pr-merge.outputs.is_pr_merge == 'true' && needs.retag-pr-image.outputs.image_retagged != 'true'
+        run: |
+          echo "⚠️ FALLBACK: Building new image because PR image retagging failed"
+          echo "This is expected in scenarios like:"
+          echo "  - PR was closed before acceptance deployment completed"
+          echo "  - PR deployment workflow failed"
+          echo "  - Image was removed from ACR by cleanup policy"
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -173,12 +233,28 @@ jobs:
     name: Deploy to Production
     runs-on: ubuntu-latest
     needs: [check-pr-merge, retag-pr-image, build-production]
+    # Deploy if either retagging OR building succeeded
+    # Note: always() ensures this runs even if one job was skipped
     if: always() && (needs.retag-pr-image.result == 'success' || needs.build-production.result == 'success')
     permissions:
-      id-token: write
-      contents: read
+      id-token: write    # Required for Azure federated credential authentication
+      contents: read     # Required for potential checkout operations
 
     steps:
+      - name: Log deployment source
+        run: |
+          if [ "${{ needs.retag-pr-image.result }}" == "success" ]; then
+            echo "🚀 Deploying retagged PR image (fast path)"
+            echo "Image was tested in acceptance environment and retagged for production"
+          elif [ "${{ needs.build-production.result }}" == "success" ]; then
+            echo "🚀 Deploying newly built image"
+            if [ "${{ needs.check-pr-merge.outputs.is_pr_merge }}" == "true" ]; then
+              echo "Built as fallback because PR image retagging failed"
+            else
+              echo "Built from direct push to main"
+            fi
+          fi
+
       - name: Log in to Azure
         uses: azure/login@v2
         with:
@@ -190,6 +266,7 @@ jobs:
         uses: azure/CLI@v2
         with:
           inlineScript: |
+            echo "Deploying image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}"
             az containerapp update \
               -n ${{ env.CONTAINER_APP_PROD }} \
               -g ${{ env.RESOURCE_GROUP }} \

--- a/.github/workflows/production-deployment.yml
+++ b/.github/workflows/production-deployment.yml
@@ -12,9 +12,90 @@ env:
   RESOURCE_GROUP: play14-community
 
 jobs:
+  check-pr-merge:
+    name: Check if PR was merged
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.check.outputs.pr_number }}
+      is_pr_merge: ${{ steps.check.outputs.is_pr_merge }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check if commit is from PR merge
+        id: check
+        run: |
+          # Check if this is a merge commit
+          if git rev-parse HEAD^2 >/dev/null 2>&1; then
+            echo "This is a merge commit"
+
+            # Extract PR number from merge commit message (format: "Merge pull request #123 from...")
+            PR_NUMBER=$(git log -1 --pretty=%B | grep -oP 'Merge pull request #\K\d+' || echo "")
+
+            if [ -n "$PR_NUMBER" ]; then
+              echo "PR number: $PR_NUMBER"
+              echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+              echo "is_pr_merge=true" >> $GITHUB_OUTPUT
+            else
+              echo "Could not extract PR number from merge commit"
+              echo "is_pr_merge=false" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "This is not a merge commit (direct push to main)"
+            echo "is_pr_merge=false" >> $GITHUB_OUTPUT
+          fi
+
+  retag-pr-image:
+    name: Retag PR Image for Production
+    runs-on: ubuntu-latest
+    needs: check-pr-merge
+    if: needs.check-pr-merge.outputs.is_pr_merge == 'true'
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Log in to Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Log in to container registry
+        run: |
+          az acr login --name play14containerregistry
+
+      - name: Retag PR image for production
+        run: |
+          PR_NUMBER=${{ needs.check-pr-merge.outputs.pr_number }}
+          PR_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${PR_NUMBER}-${{ github.sha }}"
+          PROD_SHA_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}"
+          PROD_LATEST_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+
+          echo "Pulling PR image: $PR_IMAGE"
+          docker pull "$PR_IMAGE"
+
+          echo "Tagging as: $PROD_SHA_IMAGE"
+          docker tag "$PR_IMAGE" "$PROD_SHA_IMAGE"
+
+          echo "Tagging as: $PROD_LATEST_IMAGE"
+          docker tag "$PR_IMAGE" "$PROD_LATEST_IMAGE"
+
+          echo "Pushing production tags..."
+          docker push "$PROD_SHA_IMAGE"
+          docker push "$PROD_LATEST_IMAGE"
+
+          echo "✅ Successfully retagged PR image for production"
+
   build-production:
     name: Build Production Image
     runs-on: ubuntu-latest
+    needs: check-pr-merge
+    if: needs.check-pr-merge.outputs.is_pr_merge == 'false'
     permissions:
       id-token: write
       contents: read
@@ -54,7 +135,8 @@ jobs:
   deploy:
     name: Deploy to Production
     runs-on: ubuntu-latest
-    needs: build-production
+    needs: [check-pr-merge, retag-pr-image, build-production]
+    if: always() && (needs.retag-pr-image.result == 'success' || needs.build-production.result == 'success')
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Summary
Optimizes the production deployment workflow to reuse existing PR images when a PR is merged to main, instead of rebuilding from scratch.

## Changes
- Added `check-pr-merge` job to detect PR merge commits
- Added `retag-pr-image` job to retag existing PR images with production tags
- Modified `build-production` job to only run for direct pushes to main
- Updated `deploy` job dependencies to handle both paths

## Benefits
- **Faster deployments**: Retagging takes ~30 seconds vs 3-5 minutes for rebuilding
- **Consistency**: The exact image tested in acceptance is deployed to production
- **Cost savings**: Reduces GitHub Actions build minutes consumed
- **Backwards compatible**: Direct pushes to main still trigger full builds

## Test plan
- [ ] Merge a PR and verify the workflow retags the PR image
- [ ] Push directly to main and verify the workflow builds a new image
- [ ] Verify both paths successfully deploy to production