### PR TITLE
fix: improve PR merge detection for squash and rebase merges

### DIFF
--- a/.github/workflows/production-deployment.yml
+++ b/.github/workflows/production-deployment.yml
@@ -28,33 +28,39 @@ jobs:
 
       - name: Check if commit is from PR merge
         id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          # Check if this is a merge commit
-          if git rev-parse HEAD^2 >/dev/null 2>&1; then
-            echo "This is a merge commit"
+          # Get commit message
+          COMMIT_MSG=$(git log -1 --pretty=%B)
+          echo "Commit message: $COMMIT_MSG"
 
-            # Extract PR head commit SHA (the commit that was merged, not the merge commit)
-            PR_HEAD_SHA=$(git rev-parse HEAD^2)
-            echo "PR head SHA: $PR_HEAD_SHA"
-            echo "pr_head_sha=$PR_HEAD_SHA" >> $GITHUB_OUTPUT
+          # Extract PR number from commit message
+          # Supports both formats:
+          # - Regular merge: "Merge pull request #123 from..."
+          # - Squash merge: "feat: some title (#123)"
+          PR_NUMBER=$(echo "$COMMIT_MSG" | grep -oP 'Merge pull request #\K\d+' || echo "$COMMIT_MSG" | grep -oP '\(#\K\d+(?=\))' || echo "")
 
-            # Extract PR number from merge commit message
-            # Supports both formats:
-            # - Regular merge: "Merge pull request #123 from..."
-            # - Squash merge: "feat: some title (#123)"
-            COMMIT_MSG=$(git log -1 --pretty=%B)
-            PR_NUMBER=$(echo "$COMMIT_MSG" | grep -oP 'Merge pull request #\K\d+' || echo "$COMMIT_MSG" | grep -oP '\(#\K\d+(?=\))' || echo "")
+          if [ -n "$PR_NUMBER" ]; then
+            echo "✅ Detected PR merge: #$PR_NUMBER"
+            echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
-            if [ -n "$PR_NUMBER" ]; then
-              echo "PR number: $PR_NUMBER"
-              echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+            # Get the actual PR head SHA from GitHub API
+            # This works for both regular merges and squash merges
+            echo "Fetching PR details from GitHub API..."
+            PR_DATA=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER)
+            PR_HEAD_SHA=$(echo "$PR_DATA" | jq -r '.head.sha')
+
+            if [ -n "$PR_HEAD_SHA" ] && [ "$PR_HEAD_SHA" != "null" ]; then
+              echo "✅ Retrieved PR head SHA from GitHub API: $PR_HEAD_SHA"
+              echo "pr_head_sha=$PR_HEAD_SHA" >> $GITHUB_OUTPUT
               echo "is_pr_merge=true" >> $GITHUB_OUTPUT
             else
-              echo "Could not extract PR number from merge commit"
+              echo "⚠️ Could not retrieve PR head SHA from GitHub API"
               echo "is_pr_merge=false" >> $GITHUB_OUTPUT
             fi
           else
-            echo "This is not a merge commit (direct push to main)"
+            echo "ℹ️ No PR number found - direct push to main"
             echo "is_pr_merge=false" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/production-deployment.yml
+++ b/.github/workflows/production-deployment.yml
@@ -31,24 +31,49 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set +e  # Don't exit on error, we handle errors explicitly
+
           # Get commit message
           COMMIT_MSG=$(git log -1 --pretty=%B)
           echo "Commit message: $COMMIT_MSG"
 
           # Extract PR number from commit message
-          # Supports both formats:
-          # - Regular merge: "Merge pull request #123 from..."
-          # - Squash merge: "feat: some title (#123)"
-          PR_NUMBER=$(echo "$COMMIT_MSG" | grep -oP 'Merge pull request #\K\d+' || echo "$COMMIT_MSG" | grep -oP '\(#\K\d+(?=\))' || echo "")
+          # Pattern 1: "Merge pull request #123 from..." (regular merge)
+          # Pattern 2: "feat: description (#123)" (squash/rebase merge)
+          # Note: Matches last occurrence of (#digits) to avoid matching issue references in description
+          PR_NUMBER=$(echo "$COMMIT_MSG" | grep -oP 'Merge pull request #\K\d+' || echo "$COMMIT_MSG" | grep -oP '\(#\K\d+(?=\))\s*$' || echo "")
 
           if [ -n "$PR_NUMBER" ]; then
             echo "✅ Detected PR merge: #$PR_NUMBER"
             echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
             # Get the actual PR head SHA from GitHub API
-            # This works for both regular merges and squash merges
+            # IMPORTANT: For squash/rebase merges, this SHA won't exist in main branch history
+            # because GitHub creates a new commit. However, we use this SHA to locate the
+            # PR image in ACR (tagged as pr-{number}-{head_sha} during PR deployment).
             echo "Fetching PR details from GitHub API..."
-            PR_DATA=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER)
+
+            # Check if jq is available (should be on GitHub runners by default)
+            if ! command -v jq &> /dev/null; then
+              echo "❌ ERROR: jq is not installed (required for JSON parsing)"
+              echo "is_pr_merge=false" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+
+            # Fetch PR data with error handling
+            if ! PR_DATA=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER 2>&1); then
+              echo "❌ Failed to fetch PR data from GitHub API"
+              echo "Possible causes:"
+              echo "  - Network connectivity issues"
+              echo "  - GitHub API rate limits"
+              echo "  - PR #$PR_NUMBER does not exist or was deleted"
+              echo "  - Authentication issues with GITHUB_TOKEN"
+              echo "Error details: $PR_DATA"
+              echo "is_pr_merge=false" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+
+            # Extract head SHA with validation
             PR_HEAD_SHA=$(echo "$PR_DATA" | jq -r '.head.sha')
 
             if [ -n "$PR_HEAD_SHA" ] && [ "$PR_HEAD_SHA" != "null" ]; then
@@ -56,7 +81,8 @@ jobs:
               echo "pr_head_sha=$PR_HEAD_SHA" >> $GITHUB_OUTPUT
               echo "is_pr_merge=true" >> $GITHUB_OUTPUT
             else
-              echo "⚠️ Could not retrieve PR head SHA from GitHub API"
+              echo "⚠️ Could not extract PR head SHA from API response"
+              echo "API response may be malformed or PR may be in unexpected state"
               echo "is_pr_merge=false" >> $GITHUB_OUTPUT
             fi
           else


### PR DESCRIPTION
## Problem

The current PR merge detection logic in the production deployment workflow only works for regular merge commits. It fails when using squash merge or rebase merge strategies because:

- Squash merges create a single commit without `HEAD^2`
- Rebase merges replay commits without creating a merge commit
- The `git rev-parse HEAD^2` check only detects traditional merge commits

This causes the workflow to fall back to building new images even when PR images are available in the registry.

## Solution

Replace git-based merge commit detection with GitHub API-based PR detection:

1. **Extract PR number from commit message** (works for all merge types)
   - Regular merge: `"Merge pull request #123 from..."`
   - Squash/rebase: `"feat: some title (#123)"`

2. **Fetch PR head SHA from GitHub API** using `gh api`
   - Provides the actual PR head commit SHA
   - Works regardless of merge strategy

3. **Better error handling**
   - Clear status messages with emoji indicators (✅/⚠️/ℹ️)
   - Proper fallback to `is_pr_merge=false` on failure

## Benefits

- ✅ Works with all GitHub merge strategies (merge, squash, rebase)
- ✅ More reliable PR image reuse in production deployments
- ✅ Reduces unnecessary image builds
- ✅ Better logging and debugging
- ✅ Relies on GitHub's authoritative PR data instead of git commit structure

## Testing

This PR will test the acceptance deployment workflow. Once merged (using squash or rebase), it will test the production workflow's ability to detect and reuse the PR image.